### PR TITLE
fix issues with escaped characters

### DIFF
--- a/Convert-WindowsImage.ps1
+++ b/Convert-WindowsImage.ps1
@@ -1749,6 +1749,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                 $SourcePath = "$($TempDirectory)\$(Split-Path $SourcePath -Leaf)"
 
                 $tempSource = $SourcePath
+                $tempSource = (Get-Item -LiteralPath $tempSource).FullName
             }
 
             $SourcePath  = (Resolve-Path $SourcePath).Path
@@ -2389,6 +2390,8 @@ function Write-LogMessage
         [Parameter(Position=1,Mandatory=$False)]
         [ValidateSet('Verbose', 'Debug', 'Error', 'Output', 'Warning', 'Host')][String]$logType = "Output"
         )
+    $message = $message.replace("{","{{")
+    $message = $message.replace("}","}}")
 	$message = "{0:s} [{1}] $message" -f [DateTime]::UtcNow, $env:computername
 	switch ($logType) {
 		"Verbose" { $message | Write-Verbose}


### PR DESCRIPTION
There were escaped curly braces in the message of the WriteLog function, which leads to an error in BIOS mode. And fix the problem with removing the temporary wim image from the user profile.